### PR TITLE
2本指タップで多重に次の画面が開かれる問題を修正

### DIFF
--- a/apps/app/lib/screen/home/home_screen.dart
+++ b/apps/app/lib/screen/home/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:data/data.dart';
+import 'package:easy_debounce/easy_throttle.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -82,7 +83,11 @@ class HomeScreen extends HookConsumerWidget {
       BuildContext context, HomeEventHandler eventHandler, Landmark landmark) {
     return InkWell(
       onTap: () {
-        eventHandler.onLandmarkClicked(landmark);
+        EasyThrottle.throttle(
+          'onLandmarkClicked',
+          const Duration(milliseconds: 500),
+          () => eventHandler.onLandmarkClicked(landmark),
+        );
       },
       child: Container(
         padding: const EdgeInsets.all(16),

--- a/apps/app/pubspec.lock
+++ b/apps/app/pubspec.lock
@@ -277,6 +277,14 @@ packages:
       relative: true
     source: path
     version: "0.0.1"
+  easy_debounce:
+    dependency: "direct main"
+    description:
+      name: easy_debounce
+      sha256: f082609cfb8f37defb9e37fc28bc978c6712dedf08d4c5a26f820fa10165a236
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
   fake_async:
     dependency: transitive
     description:

--- a/apps/app/pubspec.yaml
+++ b/apps/app/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   firebase_analytics: ^11.4.1
   firebase_crashlytics: ^4.3.1
   animations: ^2.0.11
+  easy_debounce: ^2.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# 気になるところ

- タップすると次の画面が開かれる2つの要素について、それぞれ2本指で同時にタップすると、次の画面が多重起動していまう。

## 期待する動作

- その操作をしても、次の画面は1つだけの起動にしたい。

# 動画

| Before | After |
| --- | --- |
|<video src="https://github.com/user-attachments/assets/c618dada-1c67-4842-a534-7986f2515906"> | <video src="https://github.com/user-attachments/assets/668e3a76-30e0-4071-91ad-a650fcbe7c7b"> | 

# 解決方法

- [easy_debounce](https://pub.dev/packages/easy_debounce) パッケージの Throttling を使用

## Debonce と Throttling の違い

Debounce は一定時間内で最後に要求された処理を実行する。
Throttling は一定時間内で最初に要求された処理を実行する。
Debounce を使うと、ユーザのタップに対して、画面遷移が遅れてしまう。
Debounce はキーボード入力中の検索に有効。今回のケースでは Throtting が有効。


# 他の選択肢

- [throttling](https://pub.dev/packages/throttling) パッケージ

# 選定基準

- Like が多い

